### PR TITLE
chore: expand quality tooling — rector, class-leak, composer scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,5 @@ jobs:
           cp .env.example .env
           php artisan key:generate
 
-      - name: Pint
-        run: vendor/bin/pint --test
-
-      - name: PHPStan
-        run: vendor/bin/phpstan analyse --no-progress
-
-      - name: Tests
-        run: php artisan test
+      - name: Run checks (tests, phpstan, pint, rector, class-leak)
+        run: composer test

--- a/app/Console/Commands/CategoryBenchmarkTree.php
+++ b/app/Console/Commands/CategoryBenchmarkTree.php
@@ -23,9 +23,9 @@ final class CategoryBenchmarkTree extends Command
     ): int
     {
         $measures = Benchmark::measure([
-            class_basename(ListCategoryTreeRecursiveAction::class) => fn() => $listCategoryTreeRecursiveAction->handle(),
-            class_basename(ListCategoryTreeAdjacencyAction::class) => fn() => $listCategoryTreeAdjacencyAction->handle(),
-            class_basename(ListCategoryTreeNestedSetAction::class) => fn() => $listCategoryTreeNestedSetAction->handle(),
+            class_basename(ListCategoryTreeRecursiveAction::class) => $listCategoryTreeRecursiveAction->handle(...),
+            class_basename(ListCategoryTreeAdjacencyAction::class) => $listCategoryTreeAdjacencyAction->handle(...),
+            class_basename(ListCategoryTreeNestedSetAction::class) => $listCategoryTreeNestedSetAction->handle(...),
         ], 100);
 
         $this->table(array_keys($measures), [$measures]);

--- a/app/Console/Commands/CategoryRepairTree.php
+++ b/app/Console/Commands/CategoryRepairTree.php
@@ -15,7 +15,7 @@ final class CategoryRepairTree extends Command
 
     public function handle(): int
     {
-        $this->components->task('Repairing category tree structure', function () {
+        $this->components->task('Repairing category tree structure', function (): void {
             (new CategoryNode())->newNestedSetQuery()->fixTree();
         });
 

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -11,7 +11,7 @@ final class RouteServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
-        $this->routes(function () {
+        $this->routes(function (): void {
             Route::prefix('api/v1')
                 ->as('api-v1:')
                 ->group(base_path('routes/api-v1.php'));

--- a/app/Providers/TelescopeServiceProvider.php
+++ b/app/Providers/TelescopeServiceProvider.php
@@ -22,14 +22,12 @@ final class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
 
         $isLocal = $this->app->environment('local');
 
-        Telescope::filter(function (IncomingEntry $entry) use ($isLocal) {
-            return $isLocal ||
-                $entry->isReportableException() ||
-                $entry->isFailedRequest() ||
-                $entry->isFailedJob() ||
-                $entry->isScheduledTask() ||
-                $entry->hasMonitoredTag();
-        });
+        Telescope::filter(fn(IncomingEntry $entry): bool => $isLocal ||
+            $entry->isReportableException() ||
+            $entry->isFailedRequest() ||
+            $entry->isFailedJob() ||
+            $entry->isScheduledTask() ||
+            $entry->hasMonitoredTag());
     }
 
     /**
@@ -57,10 +55,8 @@ final class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
      */
     protected function gate(): void
     {
-        Gate::define('viewTelescope', function ($user) {
-            return in_array($user->email, [
-                //
-            ]);
-        });
+        Gate::define('viewTelescope', fn($user): bool => in_array($user->email, [
+            //
+        ]));
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,9 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         commands: __DIR__ . '/../routes/console.php',
     )
-    ->withMiddleware(function (Middleware $middleware) {
+    ->withMiddleware(function (Middleware $middleware): void {
         $middleware->append(EnsureJsonResponse::class);
     })
-    ->withExceptions(function (Exceptions $exceptions) {
+    ->withExceptions(function (Exceptions $exceptions): void {
         //
     })->create();

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,15 @@
         "staudenmeir/laravel-adjacency-list": "^1.0"
     },
     "require-dev": {
+        "driftingly/rector-laravel": "^2.5",
         "fakerphp/faker": "^1.23",
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.13",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
-        "phpunit/phpunit": "^12.0|^13.0"
+        "phpunit/phpunit": "^12.0|^13.0",
+        "rector/rector": "^2.4",
+        "tomasvotruba/class-leak": "^2.1"
     },
     "autoload": {
         "psr-4": {
@@ -55,9 +58,22 @@
             "Composer\\Config::disableProcessTimeout",
             "@php artisan serve"
         ],
-        "test": [
+        "lint": "vendor/bin/pint",
+        "rector": "vendor/bin/rector process",
+        "test:unit": [
             "@php artisan config:clear --ansi",
             "@php artisan test"
+        ],
+        "test:lint": "vendor/bin/pint --test",
+        "test:types": "vendor/bin/phpstan analyse --no-progress --memory-limit=512M",
+        "test:rector": "vendor/bin/rector process --dry-run",
+        "test:class-leak": "vendor/bin/class-leak check app config routes bootstrap database tests --skip-suffix=Controller --skip-suffix=Seeder --skip-suffix=Factory --skip-suffix=Provider --skip-suffix=Command --skip-suffix=Middleware",
+        "test": [
+            "@test:unit",
+            "@test:types",
+            "@test:lint",
+            "@test:rector",
+            "@test:class-leak"
         ]
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8046db1e17213b5cf2d16a673796387",
+    "content-hash": "726492e2ca4e41836a6ca0631180636b",
     "packages": [
         {
             "name": "brick/math",
@@ -6214,6 +6214,42 @@
     ],
     "packages-dev": [
         {
+            "name": "driftingly/rector-laravel",
+            "version": "2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/driftingly/rector-laravel.git",
+                "reference": "0dbdd842dfdbc821cfe5f47ca7326e2502b2a107"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/driftingly/rector-laravel/zipball/0dbdd842dfdbc821cfe5f47ca7326e2502b2a107",
+                "reference": "0dbdd842dfdbc821cfe5f47ca7326e2502b2a107",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "rector/rector": "^2.2.7",
+                "webmozart/assert": "^1.11 || ^2.0"
+            },
+            "type": "rector-extension",
+            "autoload": {
+                "psr-4": {
+                    "RectorLaravel\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Rector upgrades rules for Laravel Framework",
+            "support": {
+                "issues": "https://github.com/driftingly/rector-laravel/issues",
+                "source": "https://github.com/driftingly/rector-laravel/tree/2.5.0"
+            },
+            "time": "2026-06-02T16:22:14+00:00"
+        },
+        {
             "name": "fakerphp/faker",
             "version": "v1.24.1",
             "source": {
@@ -7552,6 +7588,66 @@
             "time": "2026-06-05T03:13:07+00:00"
         },
         {
+            "name": "rector/rector",
+            "version": "2.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "reference": "cbd86024be5014d3c14d9f0b3f7aae8ecbffd62c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.1.56"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.4.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-26T21:03:22+00:00"
+        },
+        {
             "name": "sebastian/cli-parser",
             "version": "5.0.0",
             "source": {
@@ -8759,6 +8855,120 @@
                 }
             ],
             "time": "2025-12-08T11:19:18+00:00"
+        },
+        {
+            "name": "tomasvotruba/class-leak",
+            "version": "2.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/TomasVotruba/class-leak.git",
+                "reference": "c13a50f0d4593d17fb19a2278a59556662e663af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/TomasVotruba/class-leak/zipball/c13a50f0d4593d17fb19a2278a59556662e663af",
+                "reference": "c13a50f0d4593d17fb19a2278a59556662e663af",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "bin": [
+                "bin/class-leak",
+                "bin/class-leak.php"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "TomasVotruba\\ClassLeak\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Detect leaking classes",
+            "support": {
+                "issues": "https://github.com/TomasVotruba/class-leak/issues",
+                "source": "https://github.com/TomasVotruba/class-leak/tree/2.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/rectorphp",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-27T08:33:55+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9007ea6f45ecf352a9422b36644e4bfc039b9155",
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev",
+                    "dev-feature/2-0": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/2.4.0"
+            },
+            "time": "2026-05-20T13:07:01+00:00"
         }
     ],
     "aliases": [],

--- a/config/app.php
+++ b/config/app.php
@@ -103,7 +103,7 @@ return [
 
     'previous_keys' => [
         ...array_filter(
-            explode(',', env('APP_PREVIOUS_KEYS', ''))
+            explode(',', (string) env('APP_PREVIOUS_KEYS', ''))
         ),
     ],
 

--- a/config/logging.php
+++ b/config/logging.php
@@ -56,7 +56,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', env('LOG_STACK', 'single')),
+            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
             'ignore_exceptions' => false,
         ],
 

--- a/config/mail.php
+++ b/config/mail.php
@@ -48,7 +48,7 @@ return [
             'username' => env('MAIL_USERNAME'),
             'password' => env('MAIL_PASSWORD'),
             'timeout' => null,
-            'local_domain' => env('MAIL_EHLO_DOMAIN', parse_url(env('APP_URL', 'http://localhost'), PHP_URL_HOST)),
+            'local_domain' => env('MAIL_EHLO_DOMAIN', parse_url((string) env('APP_URL', 'http://localhost'), PHP_URL_HOST)),
         ],
 
         'ses' => [

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -20,7 +20,7 @@ return [
     |
     */
 
-    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+    'stateful' => explode(',', (string) env('SANCTUM_STATEFUL_DOMAINS', sprintf(
         '%s%s',
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
         Sanctum::currentApplicationUrlWithPort(),

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -78,8 +78,8 @@ return [
     */
 
     'queue' => [
-        'connection' => env('TELESCOPE_QUEUE_CONNECTION', null),
-        'queue' => env('TELESCOPE_QUEUE', null),
+        'connection' => env('TELESCOPE_QUEUE_CONNECTION'),
+        'queue' => env('TELESCOPE_QUEUE'),
         'delay' => env('TELESCOPE_QUEUE_DELAY', 10),
     ],
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -36,7 +36,7 @@ final class UserFactory extends Factory
      */
     public function unverified(): UserFactory
     {
-        return $this->state(fn(array $attributes) => [
+        return $this->state(fn(array $attributes): array => [
             'email_verified_at' => null,
         ]);
     }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -12,7 +12,7 @@ return new class() extends Migration {
      */
     public function up(): void
     {
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', function (Blueprint $table): void {
             $table->id();
             $table->string('name');
             $table->string('email')->unique();
@@ -22,13 +22,13 @@ return new class() extends Migration {
             $table->timestamps();
         });
 
-        Schema::create('password_reset_tokens', function (Blueprint $table) {
+        Schema::create('password_reset_tokens', function (Blueprint $table): void {
             $table->string('email')->primary();
             $table->string('token');
             $table->timestamp('created_at')->nullable();
         });
 
-        Schema::create('sessions', function (Blueprint $table) {
+        Schema::create('sessions', function (Blueprint $table): void {
             $table->string('id')->primary();
             $table->foreignId('user_id')->nullable()->index();
             $table->string('ip_address', 45)->nullable();

--- a/database/migrations/0001_01_01_000001_create_cache_table.php
+++ b/database/migrations/0001_01_01_000001_create_cache_table.php
@@ -12,13 +12,13 @@ return new class() extends Migration {
      */
     public function up(): void
     {
-        Schema::create('cache', function (Blueprint $table) {
+        Schema::create('cache', function (Blueprint $table): void {
             $table->string('key')->primary();
             $table->mediumText('value');
             $table->integer('expiration');
         });
 
-        Schema::create('cache_locks', function (Blueprint $table) {
+        Schema::create('cache_locks', function (Blueprint $table): void {
             $table->string('key')->primary();
             $table->string('owner');
             $table->integer('expiration');

--- a/database/migrations/0001_01_01_000002_create_jobs_table.php
+++ b/database/migrations/0001_01_01_000002_create_jobs_table.php
@@ -12,7 +12,7 @@ return new class() extends Migration {
      */
     public function up(): void
     {
-        Schema::create('jobs', function (Blueprint $table) {
+        Schema::create('jobs', function (Blueprint $table): void {
             $table->id();
             $table->string('queue')->index();
             $table->longText('payload');
@@ -22,7 +22,7 @@ return new class() extends Migration {
             $table->unsignedInteger('created_at');
         });
 
-        Schema::create('job_batches', function (Blueprint $table) {
+        Schema::create('job_batches', function (Blueprint $table): void {
             $table->string('id')->primary();
             $table->string('name');
             $table->integer('total_jobs');
@@ -35,7 +35,7 @@ return new class() extends Migration {
             $table->integer('finished_at')->nullable();
         });
 
-        Schema::create('failed_jobs', function (Blueprint $table) {
+        Schema::create('failed_jobs', function (Blueprint $table): void {
             $table->id();
             $table->string('uuid')->unique();
             $table->text('connection');

--- a/database/migrations/2025_05_18_183032_create_personal_access_tokens_table.php
+++ b/database/migrations/2025_05_18_183032_create_personal_access_tokens_table.php
@@ -12,7 +12,7 @@ return new class() extends Migration {
      */
     public function up(): void
     {
-        Schema::create('personal_access_tokens', function (Blueprint $table) {
+        Schema::create('personal_access_tokens', function (Blueprint $table): void {
             $table->id();
             $table->morphs('tokenable');
             $table->string('name');

--- a/database/migrations/2025_05_20_100214_create_categories_table.php
+++ b/database/migrations/2025_05_20_100214_create_categories_table.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Schema;
 return new class() extends Migration {
     public function up(): void
     {
-        Schema::create('categories', function (Blueprint $table) {
+        Schema::create('categories', function (Blueprint $table): void {
             $table->id();
             $table->string('name');
             $table->string('slug', 100)->unique();

--- a/database/migrations/2025_06_08_093232_create_telescope_entries_table.php
+++ b/database/migrations/2025_06_08_093232_create_telescope_entries_table.php
@@ -22,7 +22,7 @@ return new class() extends Migration {
     {
         $schema = Schema::connection($this->getConnection());
 
-        $schema->create('telescope_entries', function (Blueprint $table) {
+        $schema->create('telescope_entries', function (Blueprint $table): void {
             $table->bigIncrements('sequence');
             $table->uuid('uuid');
             $table->uuid('batch_id');
@@ -39,7 +39,7 @@ return new class() extends Migration {
             $table->index(['type', 'should_display_on_index']);
         });
 
-        $schema->create('telescope_entries_tags', function (Blueprint $table) {
+        $schema->create('telescope_entries_tags', function (Blueprint $table): void {
             $table->uuid('entry_uuid');
             $table->string('tag');
 
@@ -52,7 +52,7 @@ return new class() extends Migration {
                 ->onDelete('cascade');
         });
 
-        $schema->create('telescope_monitoring', function (Blueprint $table) {
+        $schema->create('telescope_monitoring', function (Blueprint $table): void {
             $table->string('tag')->primary();
         });
     }

--- a/database/migrations/2025_06_08_125730_add_lft_rgt_to_categories.php
+++ b/database/migrations/2025_06_08_125730_add_lft_rgt_to_categories.php
@@ -12,7 +12,7 @@ return new class() extends Migration {
      */
     public function up(): void
     {
-        Schema::table('categories', function (Blueprint $table) {
+        Schema::table('categories', function (Blueprint $table): void {
             $table->unsignedInteger('_lft')->default(0)->after('parent_id');
             $table->unsignedInteger('_rgt')->default(0)->after('_lft');
         });
@@ -23,7 +23,7 @@ return new class() extends Migration {
      */
     public function down(): void
     {
-        Schema::table('categories', function (Blueprint $table) {
+        Schema::table('categories', function (Blueprint $table): void {
             $table->dropColumn('_lft');
             $table->dropColumn('_rgt');
         });

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
@@ -54,8 +54,8 @@ final class CategorySeeder extends Seeder
                 'name' => $category,
                 'slug' => $slug,
                 'parent_id' => null,
-                'created_at' => Carbon::now(),
-                'updated_at' => Carbon::now(),
+                'created_at' => Date::now(),
+                'updated_at' => Date::now(),
             ]);
 
             $mainCategoryIds[$category] = $id;
@@ -151,8 +151,8 @@ final class CategorySeeder extends Seeder
                     'name' => $subcategory,
                     'slug' => $slug,
                     'parent_id' => $mainCategoryIds[$mainCategory],
-                    'created_at' => Carbon::now(),
-                    'updated_at' => Carbon::now(),
+                    'created_at' => Date::now(),
+                    'updated_at' => Date::now(),
                 ]);
 
                 $subCategoryIds[$subcategory] = $id;
@@ -233,8 +233,8 @@ final class CategorySeeder extends Seeder
                     'name' => $thirdLevel,
                     'slug' => $slug,
                     'parent_id' => $subCategoryIds[$parentCategory],
-                    'created_at' => Carbon::now(),
-                    'updated_at' => Carbon::now(),
+                    'created_at' => Date::now(),
+                    'updated_at' => Date::now(),
                 ]);
             }
         }
@@ -306,8 +306,8 @@ final class CategorySeeder extends Seeder
                     'name' => $name,
                     'slug' => $slug,
                     'parent_id' => $parentId,
-                    'created_at' => Carbon::now(),
-                    'updated_at' => Carbon::now(),
+                    'created_at' => Date::now(),
+                    'updated_at' => Date::now(),
                 ]);
             }
         }

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
+use RectorLaravel\Set\LaravelSetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/app',
+        __DIR__ . '/bootstrap/app.php',
+        __DIR__ . '/config',
+        __DIR__ . '/database',
+        __DIR__ . '/routes',
+        __DIR__ . '/tests',
+    ])
+    ->withPhpSets(php83: true)
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        typeDeclarations: true,
+        earlyReturn: true,
+    )
+    ->withSets([
+        LaravelSetList::LARAVEL_CODE_QUALITY,
+        LaravelSetList::LARAVEL_COLLECTION,
+        LaravelSetList::LARAVEL_IF_HELPERS,
+    ])
+    ->withSkip([
+        // Pint owns formatting; this rule fights declare_strict_types placement
+        AddOverrideAttributeToOverriddenMethodsRector::class,
+    ]);

--- a/routes/api-v1/catalog.php
+++ b/routes/api-v1/catalog.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 use App\Http\Controllers\Api\V1\CategoryController;
 use Illuminate\Support\Facades\Route;
 
-Route::prefix('catalog')->name('catalog.')->group(function () {
-    Route::prefix('categories')->name('categories.')->group(function () {
+Route::prefix('catalog')->name('catalog.')->group(function (): void {
+    Route::prefix('categories')->name('categories.')->group(function (): void {
         Route::get('tree-recursive', [CategoryController::class, 'treeRecursive'])->name('tree.recursive');
         Route::get('tree-adjacency', [CategoryController::class, 'treeAdjacency'])->name('tree.adjacency');
         Route::get('tree-nested-set', [CategoryController::class, 'treeNestedSet'])->name('tree.nested.set');


### PR DESCRIPTION
Expands the project quality pipeline:

- **rector/rector** + **driftingly/rector-laravel**: PHP 8.3 sets, deadCode/codeQuality/typeDeclarations/earlyReturn + Laravel sets; fixes applied (closure/arrow-fn return types across 21 files)
- **tomasvotruba/class-leak**: dead class detection
- **composer scripts**: `lint`, `rector`, `test:unit`, `test:lint`, `test:types`, `test:rector`, `test:class-leak`; `composer test` = full pipeline
- **CI**: single `composer test` entrypoint

Verified in docker: tests 3 passed, phpstan 0 errors, pint 50 files pass, rector clean, class-leak clean.